### PR TITLE
ignore warnings from BeautifulSoup

### DIFF
--- a/jac/base.py
+++ b/jac/base.py
@@ -2,6 +2,7 @@
 
 import os
 import hashlib
+import warnings
 from bs4 import BeautifulSoup
 
 from jac.compat import u, open, file, basestring, utf8_encode
@@ -13,6 +14,10 @@ try:
     from collections import OrderedDict # Python >= 2.7
 except ImportError:
     from ordereddict import OrderedDict # Python 2.6
+
+
+# ignore warnings from BeautifulSoup
+warnings.filterwarnings('ignore')
 
 
 class Compressor(object):


### PR DESCRIPTION
Prevents warnings like:

```
bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")
```