### PR TITLE
Explicitly give BeautifulSoup the parser so no warnings occur.

### DIFF
--- a/jac/base.py
+++ b/jac/base.py
@@ -2,7 +2,6 @@
 
 import os
 import hashlib
-import warnings
 from bs4 import BeautifulSoup
 
 from jac.compat import u, open, file, basestring, utf8_encode
@@ -14,10 +13,6 @@ try:
     from collections import OrderedDict # Python >= 2.7
 except ImportError:
     from ordereddict import OrderedDict # Python 2.6
-
-
-# ignore warnings from BeautifulSoup
-warnings.filterwarnings('ignore')
 
 
 class Compressor(object):
@@ -56,7 +51,7 @@ class Compressor(object):
             return self.render_element(filename, compression_type)
 
         assets = OrderedDict()
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         for count, c in enumerate(self.find_compilable_tags(soup)):
 
             url = c.get('src') or c.get('href')
@@ -114,7 +109,7 @@ class Compressor(object):
         return blocks
 
     def make_hash(self, html):
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         compilables = self.find_compilable_tags(soup)
         html_hash = hashlib.md5(utf8_encode(html))
 

--- a/jac/base.py
+++ b/jac/base.py
@@ -14,6 +14,12 @@ try:
 except ImportError:
     from ordereddict import OrderedDict # Python 2.6
 
+try:
+    import lxml
+    PARSER = 'lxml'
+except ImportError:
+    PARSER = 'html.parser'
+
 
 class Compressor(object):
 
@@ -51,7 +57,7 @@ class Compressor(object):
             return self.render_element(filename, compression_type)
 
         assets = OrderedDict()
-        soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, PARSER)
         for count, c in enumerate(self.find_compilable_tags(soup)):
 
             url = c.get('src') or c.get('href')
@@ -109,7 +115,7 @@ class Compressor(object):
         return blocks
 
     def make_hash(self, html):
-        soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, PARSER)
         compilables = self.find_compilable_tags(soup)
         html_hash = hashlib.md5(utf8_encode(html))
 


### PR DESCRIPTION
#32 made it so BeautifulSoup warnings were to be ignored but they were still occurring for me. The warning was pretty clear so it's better to just fix the warning itself than ignore it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/jinja-assets-compressor/40)
<!-- Reviewable:end -->
