### PR TITLE
COMPRESSOR_CLASSES config updates default compressors instead of replacing

### DIFF
--- a/jac/contrib/flask.py
+++ b/jac/contrib/flask.py
@@ -98,7 +98,8 @@ class JAC(object):
             'text/sass': SassCompressor,
             'text/scss': SassCompressor,
         }
-        app.jinja_env.compressor_classes.update(app.config.get('COMPRESSOR_CLASSES', {}))
+        if isinstance(app.config.get('COMPRESSOR_CLASSES'), dict):
+            app.jinja_env.compressor_classes.update(app.config.get('COMPRESSOR_CLASSES'))
         app.jinja_env.compressor_source_dirs = static_finder(app)
 
     def set_compressor(self, mimetype, compressor_cls):

--- a/jac/contrib/flask.py
+++ b/jac/contrib/flask.py
@@ -90,14 +90,15 @@ class JAC(object):
             os.path.join(app.static_folder, 'sdist')
         app.jinja_env.compressor_static_prefix = app.config.get('COMPRESSOR_STATIC_PREFIX') or \
             app.static_url_path + '/sdist'
-        app.jinja_env.compressor_classes = app.config.get('COMPRESSOR_CLASSES', {
+        app.jinja_env.compressor_classes = {
             'text/css': LessCompressor,
             'text/coffeescript': CoffeeScriptCompressor,
             'text/less': LessCompressor,
             'text/javascript': JavaScriptCompressor,
             'text/sass': SassCompressor,
             'text/scss': SassCompressor,
-        })
+        }
+        app.jinja_env.compressor_classes.update(app.config.get('COMPRESSOR_CLASSES', {}))
         app.jinja_env.compressor_source_dirs = static_finder(app)
 
     def set_compressor(self, mimetype, compressor_cls):


### PR DESCRIPTION
This makes adding custom compressors simpler. Instead of having to list all default compressors, your Flask config can just list custom ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/jinja-assets-compressor/52)
<!-- Reviewable:end -->
