### PR TITLE
Speed up offline compress step with in-memory cache

### DIFF
--- a/jac/base.py
+++ b/jac/base.py
@@ -37,6 +37,9 @@ class Compressor(object):
         else:
             self.config = Config(**kwargs)
 
+        # Only used to speed up offline compression script step
+        self.temp_cache = {}
+
     def compress(self, html, compression_type):
 
         if not self.config.compressor_enabled:
@@ -73,11 +76,13 @@ class Compressor(object):
                 uri_cwd = os.path.join(u(self.config.compressor_static_prefix), os.path.dirname(u(url)))
                 text = open(self.find_file(u(url)), 'r', encoding='utf-8')
                 cwd = os.path.dirname(text.name)
+                cache_key = u(url) if self.config.compressor_offline_compress else None
             else:
                 filename = u('inline{0}').format(count)
                 uri_cwd = None
                 text = c.string
                 cwd = None
+                cache_key = None
 
             mimetype = c['type'].lower()
             try:
@@ -102,12 +107,17 @@ class Compressor(object):
                 assets[outfile] = None
                 continue
 
-            text = self.get_contents(text)
-            compressed = compressor.compile(text,
-                                            mimetype=mimetype,
-                                            cwd=cwd,
-                                            uri_cwd=uri_cwd,
-                                            debug=self.config.compressor_debug)
+            if cache_key and cache_key in self.temp_cache:
+                compressed = self.temp_cache[cache_key]
+            else:
+                text = self.get_contents(text)
+                compressed = compressor.compile(text,
+                                                mimetype=mimetype,
+                                                cwd=cwd,
+                                                uri_cwd=uri_cwd,
+                                                debug=self.config.compressor_debug)
+                if cache_key:
+                    self.temp_cache[cache_key] = compressed
 
             if not os.path.exists(outfile):
                 if assets.get(outfile) is None:


### PR DESCRIPTION
Running offline compression is slow (`python -m jac.contrib.flask my_flask_module:create_app`). This change uses an in-memory hash to prevent re-compressing the same file more than once. If templates share common script files, this can speed up the offline compression step:

### Before

```
time python -m jac.contrib.flask test:app
Deleting previously compressed files in /Users/alan/projects/test/test/static/sdist
Compressing static assets into /Users/alan/projects/test/test/static/sdist
Finished offline-compressing static assets.
real	4m23.766s
user	5m4.898s
sys	0m30.058s
```

### After

```
time python -m jac.contrib.flask test:app
Deleting previously compressed files in /Users/alan/projects/test/test/static/sdist
Compressing static assets into /Users/alan/projects/test/test/static/sdist
Finished offline-compressing static assets.
real	1m37.951s
user	1m38.567s
sys	0m13.137s
```

Time saved: 2m46s

Also caches `make_hash` to prevent re-hashing the contents of static assets on every http request when offline compress is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/jinja-assets-compressor/65)
<!-- Reviewable:end -->
