### PR TITLE
use cache folder to only compress changed files

### DIFF
--- a/jac/base.py
+++ b/jac/base.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 
 from bs4 import BeautifulSoup
+from shutil import copyfile
 
 from jac.compat import basestring
 from jac.compat import file
@@ -53,6 +54,24 @@ class Compressor(object):
 
         if not os.path.exists(u(self.config.compressor_output_dir)):
             os.makedirs(u(self.config.compressor_output_dir))
+
+        if self.config.compressor_offline_compress and self.config.compressor_cache_dir:
+            cached_file = os.path.join(
+                u(self.config.compressor_cache_dir),
+                u('{hash}.{extension}').format(
+                    hash=html_hash,
+                    extension=compression_type,
+                ),
+            )
+            output_file = os.path.join(
+                u(self.config.compressor_output_dir),
+                u('{hash}.{extension}').format(
+                    hash=html_hash,
+                    extension=compression_type,
+                ),
+            )
+            if os.path.exists(cached_file) and not os.path.exists(output_file):
+                copyfile(cached_file, output_file)
 
         cached_file = os.path.join(
             u(self.config.compressor_output_dir),

--- a/jac/base.py
+++ b/jac/base.py
@@ -2,9 +2,9 @@
 
 import hashlib
 import os
+from shutil import copyfile
 
 from bs4 import BeautifulSoup
-from shutil import copyfile
 
 from jac.compat import basestring
 from jac.compat import file

--- a/jac/config.py
+++ b/jac/config.py
@@ -11,6 +11,7 @@ class Config(dict):
     _defaults = {
         'compressor_enabled': True,
         'compressor_offline_compress': False,
+        'compressor_cache_dir': '',
         'compressor_follow_symlinks': False,
         'compressor_debug': False,
         'compressor_static_prefix': '/static/dist',

--- a/jac/contrib/flask.py
+++ b/jac/contrib/flask.py
@@ -94,6 +94,9 @@ class JAC(object):
         app.jinja_env.compressor_enabled = app.config.get('COMPRESSOR_ENABLED', True)
         app.jinja_env.compressor_offline_compress = app.config.get('COMPRESSOR_OFFLINE_COMPRESS', False)
         app.jinja_env.compressor_cache_dir = app.config.get('COMPRESSOR_CACHE_DIR', None)
+        app.jinja_env.compressor_cache_dir = app.config.get('COMPRESSOR_CACHE_DIR') or \
+            app.config.get('COMPRESSOR_OUTPUT_DIR') or \
+            os.path.join(app.static_folder, 'sdist')
         app.jinja_env.compressor_follow_symlinks = app.config.get('COMPRESSOR_FOLLOW_SYMLINKS', False)
         app.jinja_env.compressor_debug = app.config.get('COMPRESSOR_DEBUG', False)
         app.jinja_env.compressor_output_dir = app.config.get('COMPRESSOR_OUTPUT_DIR') or \

--- a/jac/contrib/flask.py
+++ b/jac/contrib/flask.py
@@ -93,6 +93,7 @@ class JAC(object):
         app.jinja_env.add_extension('jac.CompressorExtension')
         app.jinja_env.compressor_enabled = app.config.get('COMPRESSOR_ENABLED', True)
         app.jinja_env.compressor_offline_compress = app.config.get('COMPRESSOR_OFFLINE_COMPRESS', False)
+        app.jinja_env.compressor_cache_dir = app.config.get('COMPRESSOR_CACHE_DIR', None)
         app.jinja_env.compressor_follow_symlinks = app.config.get('COMPRESSOR_FOLLOW_SYMLINKS', False)
         app.jinja_env.compressor_debug = app.config.get('COMPRESSOR_DEBUG', False)
         app.jinja_env.compressor_output_dir = app.config.get('COMPRESSOR_OUTPUT_DIR') or \

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -124,3 +124,28 @@ $margin: 16px
         compressor.offline_compress(env, [os.path.join(tmpdir, 'templates')])
 
         assert os.path.exists(env.compressor_output_dir) is True
+
+    def test_offline_compress_with_cache(self, env):
+        from jac import Compressor
+
+        tmpdir = str(env.compressor_output_dir)
+
+        env.compressor_offline_compress = True
+        env.compressor_source_dirs = [os.path.join(tmpdir, 'static')]
+        env.compressor_output_dir = os.path.join(tmpdir, 'dist')
+        env.compressor_cache_dir = os.path.join(tmpdir, 'cache')
+
+        compressor = Compressor(environment=env)
+        css = '<link type="text/css" rel="stylesheet" href="/static/test.css">'
+
+        os.makedirs(os.path.join(tmpdir, 'templates'))
+        with open(os.path.join(tmpdir, 'templates', 'test.html'), 'w') as fh:
+            fh.write('<html>{% compress "css" %}' + css + '{% endcompress %}</html>')
+
+        os.makedirs(os.path.join(tmpdir, 'static'))
+        with open(os.path.join(tmpdir, 'static', 'test.css'), 'w') as fh:
+            fh.write('html { display: block; }')
+
+        compressor.offline_compress(env, [os.path.join(tmpdir, 'templates')])
+
+        assert os.path.exists(env.compressor_output_dir) is True


### PR DESCRIPTION
When using offline compression and the `compressor_cache_dir` config is set to the old asset output folder, we can greatly speed up offline compression by copying files that have not changed into output folder instead of re-compiling them. For ex:

### Before

```
time python -m jac.contrib.flask test:app
Deleting previously compressed files in /Users/alan/projects/test/test/static/sdist
Compressing static assets into /Users/alan/projects/test/test/static/sdist
Finished offline-compressing static assets.
real	1m37.951s
user	1m38.567s
sys	0m13.137s
```

### After

```
time python -m jac.contrib.flask test:app
Deleting previously compressed files in /Users/alan/projects/test/test/static/sdist
Compressing static assets into /Users/alan/projects/test/test/static/sdist
Finished offline-compressing static assets.
real	0m5.676s
user	0m5.951s
sys	0m2.161s
```

Time saved: 1m32s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaysonsantos/jinja-assets-compressor/75)
<!-- Reviewable:end -->
